### PR TITLE
Dont count killed hydras

### DIFF
--- a/src/D2Reader/D2Data.cs
+++ b/src/D2Reader/D2Data.cs
@@ -119,5 +119,11 @@ namespace Zutatensuppe.D2Reader
             SUMMONED = 4, // seen for necro skeleton
             HIRELING = 7, 
         }
+
+        public enum UnitClassFlag: byte
+        {
+            IS_SELECTABLE = 8, // if unit is selectable (for attack).
+                               // flag is not set for example for chickens, hydras or npcs in town
+        }
     }
 }

--- a/src/D2Reader/D2DataReader.cs
+++ b/src/D2Reader/D2DataReader.cs
@@ -711,23 +711,21 @@ namespace Zutatensuppe.D2Reader
             var killed = new List<Monster>();
             foreach (var unit in IterateUnits(D2UnitType.Monster))
             {
-#if DEBUG
-                var tmpIsSel = unitReader.IsUnitSelectable(unit);
-                var tmpMonsterData = reader.Read<D2MonsterData>(unit.UnitData);
-                var tmpMStats = reader.Read<D2MonStats>(tmpMonsterData.pMonStats);
-                var tmpName = (reader.ReadNullTerminatedString(tmpMonsterData.szMonName, 300, Encoding.Unicode));
-                var tmpXp = unit.UnitFlags_C4.HasFlag(D2UnitFlags_C4.NO_XP) ? false : true;
-                var tmpIsDead = (MonsterMode)unit.eMode == MonsterMode.DEAD
-                    || (MonsterMode)unit.eMode == MonsterMode.DEATH;
-                Logger.Info(""
-                    + "ID:  " + unit.GUID + " "
-                    + "CLS: " + unit.eClass + " "
-                    + "NAM: " + tmpName + " "
-                    + "SEL: " + (tmpIsSel ? "y" : "n") + " "
-                    + "EXP: " + (tmpXp ? "y" : "n") + " "
-                    + "RIP: " + (tmpIsDead ? "y" : "n") + " "
-                );
-#endif
+                // var tmpIsSel = unitReader.IsUnitSelectable(unit);
+                // var tmpMonsterData = reader.Read<D2MonsterData>(unit.UnitData);
+                // var tmpMStats = reader.Read<D2MonStats>(tmpMonsterData.pMonStats);
+                // var tmpName = (reader.ReadNullTerminatedString(tmpMonsterData.szMonName, 300, Encoding.Unicode));
+                // var tmpXp = unit.UnitFlags_C4.HasFlag(D2UnitFlags_C4.NO_XP) ? false : true;
+                // var tmpIsDead = (MonsterMode)unit.eMode == MonsterMode.DEAD
+                //     || (MonsterMode)unit.eMode == MonsterMode.DEATH;
+                // Logger.Info(""
+                //     + "ID:  " + unit.GUID + " "
+                //     + "CLS: " + unit.eClass + " "
+                //     + "NAM: " + tmpName + " "
+                //     + "SEL: " + (tmpIsSel ? "y" : "n") + " "
+                //     + "EXP: " + (tmpXp ? "y" : "n") + " "
+                //     + "RIP: " + (tmpIsDead ? "y" : "n") + " "
+                // );
 
                 if (petIds.Contains(unit.GUID))
                 {

--- a/src/D2Reader/ProcessMemoryReader.cs
+++ b/src/D2Reader/ProcessMemoryReader.cs
@@ -312,7 +312,7 @@ namespace Zutatensuppe.D2Reader
         public T IndexIntoArray<T>(DataPointer array, int index, uint length) where T : class
         {
             // Index out of range.
-            if (index >= length) return null;
+            if (index < 0 || index >= length) return null;
 
             // Indexing is just taking the size of each element added to the base.
             int offset = index * Marshal.SizeOf<T>();

--- a/src/D2Reader/Struct/D2ClassDescription.cs
+++ b/src/D2Reader/Struct/D2ClassDescription.cs
@@ -5,6 +5,8 @@ namespace Zutatensuppe.D2Reader.Struct
     [StructLayout(LayoutKind.Explicit, Pack = 1, Size = 0x1A8)]
     public class D2ClassDescription
     {
-        [FieldOffset(0x0A8)] short __unknown_A8; //
+        [FieldOffset(0x018)] public short __unknown_index_18; //
+
+        [FieldOffset(0x0A8)] public short __unknown_A8; //
     }
 }

--- a/src/D2Reader/Struct/D2GlobalData.cs
+++ b/src/D2Reader/Struct/D2GlobalData.cs
@@ -4,7 +4,8 @@ namespace Zutatensuppe.D2Reader.Struct
 {
     // Where to find this?
     // 1.14D: [game.744304] points to this struct 
-    // 
+    //
+    // 1.13C: D2Common.sgptDataTables 0x6FDEFED8 contains address to this struct
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public class D2GlobalData
     {
@@ -14,7 +15,12 @@ namespace Zutatensuppe.D2Reader.Struct
 
         [FieldOffset(0x0C4)] public uint UnknownValue3; // (0xB9 => 185) related to the skill.PassiveState value (maybe it is some kind of "max" value for passive state)
 
-        // size of each ClassDescription is probably 0x1A8
+        // found used in 1.13c in D2Game.dll + 0x13B0
+        // size of each item (D2UnknownStruct for now) is 0x134 (308)
+        [FieldOffset(0xA90)] public DataPointer UnknownPointer_0A90;
+        [FieldOffset(0xA98)] public uint UnknownCount_0A98;
+
+        // size of each ClassDescription is probably 0x1A8 (424)
         [FieldOffset(0xA78)] public DataPointer ClassDescriptions;
         [FieldOffset(0xA80)] public uint ClassCount;
 
@@ -31,6 +37,7 @@ namespace Zutatensuppe.D2Reader.Struct
         [FieldOffset(0xBC4)] public DataPointer Characters; // pointer to array of D2CharacterStats
         [FieldOffset(0xBC8)] public uint CharacterCount; // how many different classes exist. D2Unit.eClass is checked against this count to see if it is valid
 
+        // D2ItemStatCost
         [FieldOffset(0xBCC)] public DataPointer ItemStatCost; 
         [FieldOffset(0xBD4)] public uint ItemStatCostCount;
 

--- a/src/D2Reader/Struct/D2Unit.cs
+++ b/src/D2Reader/Struct/D2Unit.cs
@@ -53,10 +53,10 @@ namespace Zutatensuppe.D2Reader.Struct
     {
         #region structure (sizeof = 0xF4)
         [ExpectOffset(0x0000)] public D2UnitType eType;    // 0x00
-        [ExpectOffset(0x0004)] public int eClass;          // 0x04
+        [ExpectOffset(0x0004)] public int eClass;          // 0x04 // aka dwTxtFileNo or dwTextFileNo
         [ExpectOffset(0x0008)] public int pMempool;        // 0x08
-        [ExpectOffset(0x000C)] public int GUID;            // 0x0C
-        [ExpectOffset(0x0010)] public int eMode;           // 0x10
+        [ExpectOffset(0x000C)] public int GUID;            // 0x0C // aka dwUnitId
+        [ExpectOffset(0x0010)] public int eMode;           // 0x10 // aka dwMode
         [ExpectOffset(0x0014)] public DataPointer UnitData; // 0x14
         [ExpectOffset(0x0018)] public byte actNo;          // 0x18
         [ExpectOffset(0x0019)] public byte __unknown1;     // 0x19

--- a/src/D2Reader/Struct/Monster/D2MonStats.cs
+++ b/src/D2Reader/Struct/Monster/D2MonStats.cs
@@ -7,7 +7,9 @@ using System.Threading.Tasks;
 
 namespace Zutatensuppe.D2Reader.Struct.Monster
 {
-    // the whole thing should have a length of 0x148 (424)
+    // maybe this is the same as D2ClassDescription?
+
+    // the whole thing should have a length of 0x1A8 (424)
     // it kind of represents the rows in monStats.txt
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public class D2MonStats


### PR DESCRIPTION
hydras (eg in travincal) were counted as killed units when they 'died'.
this pr changes the killed unit detection so that non-selectable units dont count anymore