### PR TITLE
Send on process found evt

### DIFF
--- a/src/D2Reader/D2DataReader.cs
+++ b/src/D2Reader/D2DataReader.cs
@@ -16,6 +16,17 @@ using static Zutatensuppe.D2Reader.D2Data;
 
 namespace Zutatensuppe.D2Reader
 {
+    public class ProcessFoundEventArgs : EventArgs
+    {
+        public ProcessFoundEventArgs(
+            ProcessInfo processInfo
+        )
+        {
+            ProcessInfo = processInfo;
+        }
+        public ProcessInfo ProcessInfo { get; }
+    }
+
     public class DataReadEventArgs : EventArgs
     {
         public DataReadEventArgs(
@@ -95,6 +106,7 @@ namespace Zutatensuppe.D2Reader
         }
 
         public event EventHandler<DataReadEventArgs> DataRead;
+        public event EventHandler<ProcessFoundEventArgs> ProcessFound;
 
         static TimeSpan POLLING_RATE_OUT_OF_GAME = TimeSpan.FromMilliseconds(50);
         static TimeSpan POLLING_RATE_INGAME = TimeSpan.FromMilliseconds(500);
@@ -179,6 +191,7 @@ namespace Zutatensuppe.D2Reader
 
             Logger.Info($"Diablo II process found:");
             Logger.Info(reader.ProcessInfo);
+            OnProcessFound(new ProcessFoundEventArgs(reader.ProcessInfo));
 
             try
             {
@@ -904,5 +917,8 @@ namespace Zutatensuppe.D2Reader
 
         protected virtual void OnDataRead(DataReadEventArgs e) =>
             DataRead?.Invoke(this, e);
+
+        protected virtual void OnProcessFound(ProcessFoundEventArgs e) =>
+            ProcessFound?.Invoke(this, e);
     }
 }

--- a/src/DiabloInterface.Lib/Services/IGameService.cs
+++ b/src/DiabloInterface.Lib/Services/IGameService.cs
@@ -15,6 +15,11 @@ namespace Zutatensuppe.DiabloInterface.Lib.Services
         GameDifficulty TargetDifficulty { get; set; }
 
         /// <summary>
+        ///     Occurs when a game process has been found
+        /// </summary>
+        event EventHandler<ProcessFoundEventArgs> ProcessFound;
+
+        /// <summary>
         ///     Occurs when data has been successfully read from the game.
         /// </summary>
         event EventHandler<DataReadEventArgs> DataRead;

--- a/src/DiabloInterface.Plugin.HttpClient/RequestBody.cs
+++ b/src/DiabloInterface.Plugin.HttpClient/RequestBody.cs
@@ -47,6 +47,8 @@ namespace DiabloInterface.Plugin.HttpClient
             "MagicFind",
         };
 
+        public string Event { get; private set; }
+
         public string Headers { get; set; }
         public int? Area { get; set; }
         public byte? InventoryTab { get; set; }
@@ -106,6 +108,7 @@ namespace DiabloInterface.Plugin.HttpClient
         {
             return new RequestBody()
             {
+                Event = "DataRead",
                 Area = e.Game.Area,
                 InventoryTab = e.Game.InventoryTab,
                 Difficulty = e.Game.Difficulty,
@@ -166,15 +169,21 @@ namespace DiabloInterface.Plugin.HttpClient
             };
         }
 
+        public static RequestBody FromProcessFoundEventArgs(ProcessFoundEventArgs e, IDiabloInterface di)
+        {
+            return new RequestBody()
+            {
+                Event = "ProcessFound",
+                D2ProcessInfo = e.ProcessInfo,
+                DIApplicationInfo = di.appInfo,
+            };
+        }
+
         public static RequestBody GetDiff(
             RequestBody curr,
             RequestBody prev
         ) {
-            var diff = new RequestBody()
-            {
-                Name = curr.Name,
-                Guid = curr.Guid,
-            };
+            var diff = new RequestBody();
 
             // TODO: while this check is correct, D2DataReader should probably
             //       provide the information about 'new char or not' directly
@@ -235,6 +244,10 @@ namespace DiabloInterface.Plugin.HttpClient
 
             if (hasDiff)
             {
+                diff.Event = curr.Event;
+                diff.Name = curr.Name;
+                diff.Guid = curr.Guid;
+
                 // always send application info, if something is sent
                 diff.DIApplicationInfo = curr.DIApplicationInfo;
 

--- a/src/DiabloInterface/Services/GameService.cs
+++ b/src/DiabloInterface/Services/GameService.cs
@@ -31,6 +31,7 @@ namespace Zutatensuppe.DiabloInterface.Services
                 new GameMemoryTableFactory(),
                 di.configService.CurrentConfig.ProcessDescriptions
             );
+            DataReader.ProcessFound += OnProcessFound;
             DataReader.DataRead += OnDataRead;
 
             Logger.Info("Initializing data reader thread.");
@@ -44,6 +45,7 @@ namespace Zutatensuppe.DiabloInterface.Services
 
         public GameDifficulty TargetDifficulty { get; set; } = GameDifficulty.Normal;
 
+        public event EventHandler<ProcessFoundEventArgs> ProcessFound;
         public event EventHandler<DataReadEventArgs> DataRead;
 
         public void Dispose()
@@ -62,6 +64,7 @@ namespace Zutatensuppe.DiabloInterface.Services
             {
                 if (DataReader != null)
                 {
+                    DataReader.ProcessFound -= OnProcessFound;
                     DataReader.DataRead -= OnDataRead;
 
                     DataReader.Dispose();
@@ -71,6 +74,9 @@ namespace Zutatensuppe.DiabloInterface.Services
 
             isDisposed = true;
         }
+
+        void OnProcessFound(object sender, ProcessFoundEventArgs e) =>
+            ProcessFound?.Invoke(sender, e);
 
         void OnDataRead(object sender, DataReadEventArgs e) =>
             DataRead?.Invoke(sender, e);


### PR DESCRIPTION
>  Hey is it possible to send client data like version and -w stuff during initial client load instead of char load?

This adds sending a request via http client whenever a game process was found (d2 started, d2 restarted, di started while d2 running).
The new requests look like the ones we sent so far, but lots of data is omitted because it is not available at that point.

Example json:
```
{
  "Event": "ProcessFound",
  "Headers": "whatever was configured",
  "D2ProcessInfo": {
    "Type": "D2",
    "Version": "1.14d",
    "CommandLineArgs": ["-w","-seed","123"]
  },
  "DIApplicationInfo":{
    "Version":"21.3.13"
  }
}
```

To be able to distinguish between the different events the data read events we sent so far also contain `Event` with the value `"DataRead"`

In case this distinction is not needed, I can remove the `Event` key again, I was unsure whether it was required, let me know  ^^