### PR TITLE
fix stats reading in case there are multiple with same lostat identifier

### DIFF
--- a/src/D2Reader/Readers/UnitReader.cs
+++ b/src/D2Reader/Readers/UnitReader.cs
@@ -85,10 +85,11 @@ namespace Zutatensuppe.D2Reader.Readers
 
         public Dictionary<StatIdentifier, D2Stat> GetStatsMap(D2Unit unit)
         {
-            return (from stat in GetStats(unit)
-                    where stat.HasValidLoStatIdentifier()
-                    group stat by (StatIdentifier)stat.LoStatID into g
-                    select g).ToDictionary(x => x.Key, x => x.Single());
+            var tmp = (from stat in GetStats(unit)
+                       where stat.HasValidLoStatIdentifier()
+                       group stat by (StatIdentifier)stat.LoStatID into g
+                       select g);
+            return tmp.ToDictionary(x => x.Key, x => x.First());
         }
 
         public int? GetStatValue(D2Unit unit, ushort statId)

--- a/src/DiabloInterface/Properties/AssemblyInfo.cs
+++ b/src/DiabloInterface/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("25bb3310-9bd7-4234-af7d-9f7fb6870a20")]
 
-[assembly: AssemblyVersion("21.6.12")]
-[assembly: AssemblyInformationalVersion("21.6.12")]
+[assembly: AssemblyVersion("21.6.16")]
+[assembly: AssemblyInformationalVersion("21.6.16")]


### PR DESCRIPTION
In case there were multiple stats with same LoStatID the GetStatsMap function would break.
So instead of using x.Single() we now use x.First().

The bug is exposed by adding more StatIdentifiers, specifically in this case stat 0x6B (https://github.com/DiabloRun/DiabloInterface/commit/1501edcf81cb625fd0df14ba58adf22a9b543149#diff-81eadb67a3a99129f099fe8d0230e9f7f1de1b30ea59330ae814d880fbf75f88R133) which occurs multiple times for the attached character save (leaf equipped)

The stat 0x6B is not used atm for anything and was just added for documentation purpose, so this fix should be fine, but needs more investigation.

[rose.zip](https://github.com/DiabloRun/DiabloInterface/files/6660927/rose.zip)
